### PR TITLE
Support local files

### DIFF
--- a/diff/jobdiff.go
+++ b/diff/jobdiff.go
@@ -28,8 +28,8 @@ type Diff struct {
 
 func (s *Diff) ReleaseDiff(releaseURLA, releaseURLB string) (diffset []string, err error) {
 	release := pull.NewRelease(s.CacheDir)
-	filenameA := release.Pull(releaseURLA)
-	filenameB := release.Pull(releaseURLB)
+	filenameA, _ := release.Pull(releaseURLA)
+	filenameB, _ := release.Pull(releaseURLB)
 	GetReleaseManifest(filenameA)
 	GetReleaseManifest(filenameB)
 	return

--- a/diff/jobdiff.go
+++ b/diff/jobdiff.go
@@ -36,12 +36,24 @@ func (s *Diff) ReleaseDiff(releaseURLA, releaseURLB string) (diffset []string, e
 }
 
 func (s *Diff) JobDiffBetweenReleases(jobname, releaseURLA, releaseURLB string) (diffset []string, err error) {
-	var jobA *tar.Reader
-	var jobB *tar.Reader
-	var ok bool
+	var (
+		jobA      *tar.Reader
+		jobB      *tar.Reader
+		filenameA string
+		filenameB string
+		ok        bool
+	)
 	release := pull.NewRelease(s.CacheDir)
-	filenameA, _ := release.Pull(releaseURLA)
-	filenameB, _ := release.Pull(releaseURLB)
+	filenameA, err = release.Pull(releaseURLA)
+	if err != nil {
+		err = fmt.Errorf("An error occurred downloading %s. %s", releaseURLA, err.Error())
+		return
+	}
+	filenameB, err = release.Pull(releaseURLB)
+	if err != nil {
+		err = fmt.Errorf("An error occurred downloading %s. %s", releaseURLB, err.Error())
+		return
+	}
 	jobA, ok = ProcessReleaseArchive(filenameA)[jobname]
 
 	if !ok {

--- a/diff/jobdiff.go
+++ b/diff/jobdiff.go
@@ -11,10 +11,11 @@ import (
 	"path"
 	"strings"
 
+	"gopkg.in/yaml.v1"
+
 	"github.com/kr/pretty"
 	"github.com/xchapter7x/enaml"
 	"github.com/xchapter7x/enaml/pull"
-	"gopkg.in/yaml.v2"
 )
 
 func NewDiff(cacheDir string) *Diff {
@@ -39,8 +40,8 @@ func (s *Diff) JobDiffBetweenReleases(jobname, releaseURLA, releaseURLB string) 
 	var jobB *tar.Reader
 	var ok bool
 	release := pull.NewRelease(s.CacheDir)
-	filenameA := release.Pull(releaseURLA)
-	filenameB := release.Pull(releaseURLB)
+	filenameA, _ := release.Pull(releaseURLA)
+	filenameB, _ := release.Pull(releaseURLB)
 	jobA, ok = ProcessReleaseArchive(filenameA)[jobname]
 
 	if !ok {

--- a/diff/jobdiff_test.go
+++ b/diff/jobdiff_test.go
@@ -35,7 +35,7 @@ var _ = Describe("jobdiff", func() {
 		Describe("given JobDiffBetweenReleases method", func() {
 			Context("when calling JobDiffBetweenReleases on 2 releases with unchanged properties", func() {
 				It("then it should return an empty changeset", func() {
-					diff, err := diff.JobDiffBetweenReleases("atc", "url.com/concourse?v=1.1.0", "url.com/concourse?v=1.1.0")
+					diff, err := diff.JobDiffBetweenReleases("atc", "http://url.com/concourse?v=1.1.0", "http://url.com/concourse?v=1.1.0")
 					Ω(diff).Should(BeEmpty())
 					Ω(err).ShouldNot(HaveOccurred())
 				})

--- a/diff/jobdiff_test.go
+++ b/diff/jobdiff_test.go
@@ -26,7 +26,7 @@ var _ = Describe("jobdiff", func() {
 
 			Context("when calling ReleaseDiff with releases that have changed", func() {
 				It("then there should not be any changes", func() {
-					diffset, err := diff.ReleaseDiff("url.com/concourse?v=1.1.0", "url.com/concourse?v=1.1.0")
+					diffset, err := diff.ReleaseDiff("http://url.com/concourse?v=1.1.0", "http://url.com/concourse?v=1.1.0")
 					Ω(err).ShouldNot(HaveOccurred())
 					Ω(diffset).Should(BeEmpty())
 				})
@@ -43,7 +43,7 @@ var _ = Describe("jobdiff", func() {
 
 			Context("when calling JobDiffBetweenReleases on 2 releases with different properties on the given job", func() {
 				It("then it should return the diff set", func() {
-					diff, err := diff.JobDiffBetweenReleases("atc", "url.com/concourse?v=1.0.1", "url.com/concourse?v=1.1.0")
+					diff, err := diff.JobDiffBetweenReleases("atc", "http://url.com/concourse?v=1.0.1", "http://url.com/concourse?v=1.1.0")
 					Ω(diff).ShouldNot(BeEmpty())
 					Ω(err).ShouldNot(HaveOccurred())
 				})

--- a/generators/releasejobs.go
+++ b/generators/releasejobs.go
@@ -23,7 +23,12 @@ func GenerateReleaseJobsPackage(releaseURL string, cacheDir string, outputDir st
 		OutputDir: outputDir,
 	}
 	release := pull.NewRelease(cacheDir)
-	filename, _ := release.Pull(releaseURL)
+	var filename string
+	filename, err = release.Pull(releaseURL)
+	if err != nil {
+		err = fmt.Errorf("An error occurred downloading %s. %s", releaseURL, err.Error())
+		return
+	}
 	gen.ProcessFile(filename)
 	return
 }

--- a/generators/releasejobs.go
+++ b/generators/releasejobs.go
@@ -12,9 +12,10 @@ import (
 	"strings"
 	"text/template"
 
+	"gopkg.in/yaml.v1"
+
 	"github.com/xchapter7x/enaml"
 	"github.com/xchapter7x/enaml/pull"
-	"gopkg.in/yaml.v2"
 )
 
 func GenerateReleaseJobsPackage(releaseURL string, cacheDir string, outputDir string) (err error) {
@@ -22,7 +23,7 @@ func GenerateReleaseJobsPackage(releaseURL string, cacheDir string, outputDir st
 		OutputDir: outputDir,
 	}
 	release := pull.NewRelease(cacheDir)
-	filename := release.Pull(releaseURL)
+	filename, _ := release.Pull(releaseURL)
 	gen.ProcessFile(filename)
 	return
 }

--- a/pull/releasepull.go
+++ b/pull/releasepull.go
@@ -22,33 +22,37 @@ type Release struct {
 
 // Pull downloads the specified Release to the local cache dir
 func (s *Release) Pull(url string) (filename string, err error) {
-
 	name := path.Base(url)
 	filename = s.CacheDir + "/" + name
 
 	if _, err = os.Stat(filename); os.IsNotExist(err) {
 		fmt.Println("Could not find release in local cache. Downloading now.")
-		var out *os.File
-		out, err = os.Create(filename)
-		if err != nil {
-			return
-		}
-		var resp *http.Response
-		resp, err = http.Get(url)
-		if err != nil {
-			return
-		}
-		defer func() {
-			if cerr := resp.Body.Close(); cerr != nil {
-				err = cerr
-			}
-		}()
-
-		progressR := &ioprogress.Reader{
-			Reader: resp.Body,
-			Size:   resp.ContentLength,
-		}
-		_, err = io.Copy(out, progressR)
+		err = s.download(url, filename)
 	}
+	return
+}
+
+func (s *Release) download(url, local string) (err error) {
+	var out *os.File
+	out, err = os.Create(local)
+	if err != nil {
+		return
+	}
+	var resp *http.Response
+	resp, err = http.Get(url)
+	if err != nil {
+		return
+	}
+	defer func() {
+		if cerr := resp.Body.Close(); cerr != nil {
+			err = cerr
+		}
+	}()
+
+	progressR := &ioprogress.Reader{
+		Reader: resp.Body,
+		Size:   resp.ContentLength,
+	}
+	_, err = io.Copy(out, progressR)
 	return
 }

--- a/pull/releasepull.go
+++ b/pull/releasepull.go
@@ -21,18 +21,18 @@ type Release struct {
 }
 
 // Pull downloads the specified Release to the local cache dir
-func (s *Release) Pull(url string) (filename string, err error) {
+func (r *Release) Pull(url string) (filename string, err error) {
 	name := path.Base(url)
-	filename = s.CacheDir + "/" + name
+	filename = r.CacheDir + "/" + name
 
 	if _, err = os.Stat(filename); os.IsNotExist(err) {
 		fmt.Println("Could not find release in local cache. Downloading now.")
-		err = s.download(url, filename)
+		err = r.download(url, filename)
 	}
 	return
 }
 
-func (s *Release) download(url, local string) (err error) {
+func (r *Release) download(url, local string) (err error) {
 	var out *os.File
 	out, err = os.Create(local)
 	if err != nil {

--- a/pull/releasepull.go
+++ b/pull/releasepull.go
@@ -10,10 +10,12 @@ import (
 	"github.com/mitchellh/ioprogress"
 )
 
+// NewRelease creates a new Release instance
 func NewRelease(cache string) *Release {
 	return &Release{CacheDir: cache}
 }
 
+// Release is a BOSH release with a configurable cache dir
 type Release struct {
 	CacheDir string
 }

--- a/pull/releasepull.go
+++ b/pull/releasepull.go
@@ -18,22 +18,35 @@ type Release struct {
 	CacheDir string
 }
 
-func (s *Release) Pull(url string) (filename string) {
+// Pull downloads the specified Release to the local cache dir
+func (s *Release) Pull(url string) (filename string, err error) {
 
 	name := path.Base(url)
 	filename = s.CacheDir + "/" + name
 
-	if _, err := os.Stat(filename); os.IsNotExist(err) {
+	if _, err = os.Stat(filename); os.IsNotExist(err) {
 		fmt.Println("Could not find release in local cache. Downloading now.")
-		out, _ := os.Create(filename)
-		resp, _ := http.Get(url)
-		defer resp.Body.Close()
+		var out *os.File
+		out, err = os.Create(filename)
+		if err != nil {
+			return
+		}
+		var resp *http.Response
+		resp, err = http.Get(url)
+		if err != nil {
+			return
+		}
+		defer func() {
+			if cerr := resp.Body.Close(); cerr != nil {
+				err = cerr
+			}
+		}()
 
 		progressR := &ioprogress.Reader{
 			Reader: resp.Body,
 			Size:   resp.ContentLength,
 		}
-		io.Copy(out, progressR)
+		_, err = io.Copy(out, progressR)
 	}
 	return
 }

--- a/pull/releasepull_test.go
+++ b/pull/releasepull_test.go
@@ -34,7 +34,7 @@ var _ = Describe("given Release object", func() {
 				Ω(filename).Should(Equal(path.Join(controlCacheDir, releaseName)))
 			})
 		})
-		Context("when called on a local release", func() {
+		Context("when called on an existing local release", func() {
 			var (
 				releaseName        = "concourse?v=1.1.0"
 				controlReleaseFile = "fixtures/" + releaseName
@@ -53,6 +53,24 @@ var _ = Describe("given Release object", func() {
 			})
 			It("returns the same local file", func() {
 				Ω(filename).Should(Equal(controlReleaseFile))
+			})
+		})
+		Context("when called on a local release that does not exist", func() {
+			var (
+				releaseName        = "foobar?v=1.0"
+				controlReleaseFile = "fixtures/" + releaseName
+				controlCacheDir    = "shouldnotbeused"
+				release            *Release
+				filename           string
+				err                error
+			)
+
+			BeforeEach(func() {
+				release = NewRelease(controlCacheDir)
+				filename, err = release.Pull(controlReleaseFile)
+			})
+			It("should have errored", func() {
+				Ω(err).Should(MatchError("Could not pull fixtures/foobar?v=1.0. The file doesn't exist or isn't a valid http(s) URL"))
 			})
 		})
 	})

--- a/pull/releasepull_test.go
+++ b/pull/releasepull_test.go
@@ -34,5 +34,26 @@ var _ = Describe("given Release object", func() {
 				Ω(filename).Should(Equal(path.Join(controlCacheDir, releaseName)))
 			})
 		})
+		Context("when called on a local release", func() {
+			var (
+				releaseName        = "concourse?v=1.1.0"
+				controlReleaseFile = "fixtures/" + releaseName
+				controlCacheDir    = "shouldnotbeused"
+				release            *Release
+				filename           string
+				err                error
+			)
+
+			BeforeEach(func() {
+				release = NewRelease(controlCacheDir)
+				filename, err = release.Pull(controlReleaseFile)
+			})
+			It("should not have errored", func() {
+				Ω(err).ShouldNot(HaveOccurred())
+			})
+			It("returns the same local file", func() {
+				Ω(filename).Should(Equal(controlReleaseFile))
+			})
+		})
 	})
 })

--- a/pull/releasepull_test.go
+++ b/pull/releasepull_test.go
@@ -12,21 +12,26 @@ import (
 var _ = Describe("given Release object", func() {
 	Describe("given a Pull method", func() {
 		Context("when called on a valid release in the cache", func() {
-			var release = "concourse?v=1.1.0"
-			var controlReleaseURL = "https://bosh.io/d/github.com/concourse/" + release
-			var controlCacheDir = "fixtures"
-			var filename string
+			var (
+				releaseName       = "concourse?v=1.1.0"
+				controlReleaseURL = "https://bosh.io/d/github.com/concourse/" + releaseName
+				controlCacheDir   = "fixtures"
+				release           *Release
+				filename          string
+				err               error
+			)
 
 			BeforeEach(func() {
-				release := NewRelease(controlCacheDir)
-				filename = release.Pull(controlReleaseURL)
+				release = NewRelease(controlCacheDir)
+				filename, err = release.Pull(controlReleaseURL)
+				Ω(err).ShouldNot(HaveOccurred())
 			})
 
 			It("then it should return a valid filename", func() {
-				_, err := os.Stat(filename)
+				_, err = os.Stat(filename)
 				Ω(err).ShouldNot(HaveOccurred())
 				Ω(filename).ShouldNot(BeEmpty())
-				Ω(filename).Should(Equal(path.Join(controlCacheDir, release)))
+				Ω(filename).Should(Equal(path.Join(controlCacheDir, releaseName)))
 			})
 		})
 	})

--- a/pull/releasepull_test.go
+++ b/pull/releasepull_test.go
@@ -11,14 +11,17 @@ import (
 
 var _ = Describe("given Release object", func() {
 	Describe("given a Pull method", func() {
+		var (
+			release  *Release
+			filename string
+			err      error
+		)
+
 		Context("when called on a valid release in the cache", func() {
 			var (
 				releaseName       = "concourse?v=1.1.0"
 				controlReleaseURL = "https://bosh.io/d/github.com/concourse/" + releaseName
 				controlCacheDir   = "fixtures"
-				release           *Release
-				filename          string
-				err               error
 			)
 
 			BeforeEach(func() {
@@ -34,20 +37,19 @@ var _ = Describe("given Release object", func() {
 				Ω(filename).Should(Equal(path.Join(controlCacheDir, releaseName)))
 			})
 		})
+
 		Context("when called on an existing local release", func() {
 			var (
 				releaseName        = "concourse?v=1.1.0"
 				controlReleaseFile = "fixtures/" + releaseName
 				controlCacheDir    = "shouldnotbeused"
-				release            *Release
-				filename           string
-				err                error
 			)
 
 			BeforeEach(func() {
 				release = NewRelease(controlCacheDir)
 				filename, err = release.Pull(controlReleaseFile)
 			})
+
 			It("should not have errored", func() {
 				Ω(err).ShouldNot(HaveOccurred())
 			})
@@ -55,20 +57,13 @@ var _ = Describe("given Release object", func() {
 				Ω(filename).Should(Equal(controlReleaseFile))
 			})
 		})
-		Context("when called on a local release that does not exist", func() {
-			var (
-				releaseName        = "foobar?v=1.0"
-				controlReleaseFile = "fixtures/" + releaseName
-				controlCacheDir    = "shouldnotbeused"
-				release            *Release
-				filename           string
-				err                error
-			)
 
+		Context("when called on a local release that does not exist", func() {
 			BeforeEach(func() {
-				release = NewRelease(controlCacheDir)
-				filename, err = release.Pull(controlReleaseFile)
+				release = NewRelease("ignored")
+				filename, err = release.Pull("fixtures/foobar?v=1.0")
 			})
+
 			It("should have errored", func() {
 				Ω(err).Should(MatchError("Could not pull fixtures/foobar?v=1.0. The file doesn't exist or isn't a valid http(s) URL"))
 			})


### PR DESCRIPTION
Supports diffing BOSH releases that have already been downloaded outside enaml. Eventually this will lead into supporting locally downloaded .pivotal releases.
- Added diff-job support for local files
- Added additional error handling in download function

```
enaml diff-job redis ~/Downloads/redis-boshrelease-1.tgz ~/Downloads/redis-boshrelease-12.tgz
0 :  Properties["redis.master"]: (missing) != {"IP address or hostname of the Redis master node" <nil>}
1 :  Properties["consul.service.name"]: (missing) != {"Name for advertising/discovering this service over consul (defaults to deployment name)" <nil>}
2 :  Properties["health.interval"]: (missing) != {"Interval for consul to perform health checks" "20s"}
3 :  Properties["health.disk.critical"]: (missing) != {"Percentage of persistent disk full to trigger critial health alert" 'b'}
4 :  Properties["health.disk.warning"]: (missing) != {"Percentage of persistent disk full to trigger warning health alert" '2'}
```
