### PR TITLE
Update cli usage

### DIFF
--- a/cmd/enaml/main.go
+++ b/cmd/enaml/main.go
@@ -23,72 +23,86 @@ func init() {
 }
 
 const (
-	CacheDir  = ".cache"
+	// CacheDir is the location downloaded releases are stored
+	CacheDir = ".cache"
+	// OutputDir is where the generate command outputs generated structs
 	OutputDir = "./enaml-gen"
 )
 
 var (
-	Version   string
-	cacheDir  = CacheDir
-	outputDir = OutputDir
+	// Version is the enaml version
+	Version     string
+	cacheDir    = CacheDir
+	outputDir   = OutputDir
+	releaseRepo = pull.Release{CacheDir: cacheDir}
 )
 
 func main() {
+	var err error
 	app := cli.NewApp()
+	app.Name = "enaml"
+	app.Usage = "Because (EN)ough with the y(AML) already"
+	app.Authors = []cli.Author{
+		cli.Author{
+			Name: "John Calabrese",
+		},
+		cli.Author{
+			Name: "Caleb Washburn",
+		},
+		cli.Author{
+			Name:  "Shawn Neal",
+			Email: "sneal@sneal.net",
+		},
+	}
 	app.Version = Version
 	app.Commands = []cli.Command{
 		{
-			Name:        "generate-jobs",
-			Aliases:     []string{"gj"},
-			Usage:       "generate-jobs <releaseurl>",
-			Description: "generate golang structs for the jobs in a given release",
+			Name:      "generate",
+			Usage:     "Generate golang structs for a given release",
+			ArgsUsage: "<releaseURL>",
+
 			Action: func(c *cli.Context) {
 				generators.GenerateReleaseJobsPackage(c.Args().First(), cacheDir, OutputDir)
 				println("completed generating release job structs for ", c.Args().First())
 			},
 		},
 		{
-			Name:    "diff-release",
-			Aliases: []string{"dr"},
-			Usage:   "show a diff between 2 releases given",
+			Name:      "diff",
+			Usage:     "Show changes between two releases",
+			ArgsUsage: "<release1URL> <release2URL>",
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "job, j",
+					Usage: "Focus the command to a specific named `JOB`",
+				},
+			},
 			Action: func(c *cli.Context) {
-				d := run.NewDiffCmd(pull.Release{CacheDir: cacheDir}, c.Args()[0], c.Args()[1])
-				err := d.All(os.Stdout)
-				if err != nil {
-					fmt.Println(err.Error())
-					os.Exit(1)
+				d := run.NewDiffCmd(releaseRepo, c.Args()[0], c.Args()[1])
+				if len(c.String("job")) > 0 {
+					err = d.Job(c.String("job"), os.Stdout)
+				} else {
+					err = d.All(os.Stdout)
 				}
+				ifErrorDisplayAndExit(err)
 			},
 		},
 		{
-			Name:        "diff-job",
-			Aliases:     []string{"dj"},
-			Usage:       "diff-job <jobname> <releaseurl-A> <releaseurl-B>",
-			Description: "show diff between jobs across 2 releases",
+			Name:      "show",
+			Usage:     "Show details about the release",
+			ArgsUsage: "<releaseURL>",
 			Action: func(c *cli.Context) {
-				d := run.NewDiffCmd(pull.Release{CacheDir: cacheDir}, c.Args()[1], c.Args()[2])
-				err := d.Job(c.Args()[0], os.Stdout)
-				if err != nil {
-					fmt.Println(err.Error())
-					os.Exit(1)
-				}
-			},
-		},
-		{
-			Name:        "show",
-			Aliases:     []string{"sh"},
-			Usage:       "show <releaseurl>",
-			Description: "show all jobs and properties from the specified release",
-			Action: func(c *cli.Context) {
-				releaseRepo := pull.Release{CacheDir: cacheDir}
 				s := run.NewShowCmd(releaseRepo, c.Args()[0])
 				err := s.All(os.Stdout)
-				if err != nil {
-					fmt.Println(err.Error())
-					os.Exit(1)
-				}
+				ifErrorDisplayAndExit(err)
 			},
 		},
 	}
 	app.Run(os.Args)
+}
+
+func ifErrorDisplayAndExit(err error) {
+	if err != nil {
+		fmt.Println(err.Error())
+		os.Exit(1)
+	}
 }

--- a/glide.lock
+++ b/glide.lock
@@ -1,10 +1,14 @@
 hash: 43037f9710cf5991c1f485e44a928a5d7c99e0a69f111c63cde4c261501fd74d
-updated: 2016-04-20T13:02:58.569792546-04:00
+updated: 2016-05-06T14:04:53.252358394-07:00
 imports:
 - name: github.com/codegangsta/cli
-  version: 71f57d300dd6a780ac1856c005c4b518cfd498ec
+  version: 75b97d09d9f5792ff997e249a330a3ca28f8b537
+- name: github.com/golang/protobuf
+  version: 7cc19b78d562895b13596ddce7aafb59dd789318
 - name: github.com/kr/pretty
   version: add1dbc86daf0f983cd4a48ceb39deb95c729b67
+- name: github.com/kr/pty
+  version: f7ee69f31298ecbe5d2b349c711e2547a617d398
 - name: github.com/kr/text
   version: bb797dc4fb8320488f47bf11de07a733d7233e1f
 - name: github.com/mitchellh/ioprogress


### PR DESCRIPTION
Streamlined the amount of commands and added a --job flag. Examples:

```
enaml generate https://bosh.io/d/github.com/cloudfoundry-community/xip-release?v=2
enaml show https://bosh.io/d/github.com/cloudfoundry-community/xip-release?v=2
enaml diff https://bosh.io/d/github.com/cloudfoundry-community/xip-release?v=1 https://bosh.io/d/github.com/cloudfoundry-community/xip-release?v=2
enaml diff --job xip https://bosh.io/d/github.com/cloudfoundry-community/xip-release?v=1 https://bosh.io/d/github.com/cloudfoundry-community/xip-release?v=2
```
